### PR TITLE
typos in inline docs & move deposit_event to the end

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -387,7 +387,7 @@ pub mod pallet {
         /// Add a new Super Admin.
         /// Admins have access to execute and manage all pallets.
         ///
-        /// Only _root_ and Admins can add an Admin.
+        /// Only _root_ can add an Admin.
         #[pallet::call_index(4)]
         #[pallet::weight(10_000_000)]
         pub fn add_admin(origin: OriginFor<T>, account_id: T::AccountId) -> DispatchResult {
@@ -404,7 +404,7 @@ pub mod pallet {
 
         /// Revokes admin privileges
         ///
-        /// Only _root_ and Admins can revoke an admin privilege
+        /// Only _root_ can revoke an admin privilege
         #[pallet::call_index(5)]
         #[pallet::weight(10_000_000)]
         pub fn revoke_admin(origin: OriginFor<T>, account_id: T::AccountId) -> DispatchResult {
@@ -425,7 +425,7 @@ impl<T: Config> Pallet<T> {
     /// Verify that account can execute an extrinsic on a pallet.
     /// Access is denied when then a pallet and an extrinsic has a access_control,
     /// and the account does not have permission to execute.
-    /// _root_, Admins will bypass this check,
+    /// _root_ will bypass this check,
     /// people in the `execute` group can pass this verification
     pub fn verify_execute_access(
         signer: &T::AccountId,
@@ -437,7 +437,7 @@ impl<T: Config> Pallet<T> {
 
     /// Verify the ability to manage the access to a pallets extrinsics.
     /// this is used for managing `execute` and `manage` privileges for a pallet
-    /// _root_, Admins will bypass this check,
+    /// _root_ will bypass this check,
     /// people in the `manage` group can pass this verification
     pub fn verify_manage_access(
         signer: &T::AccountId,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -219,10 +219,10 @@ pub mod pallet {
                 None => Vec::new(),
             };
 
-            Self::deposit_event(Event::ActionCreated(pallet_name, pallet_extrinsic));
-
             AccessControls::<T>::insert(execute_action, accounts.clone());
             AccessControls::<T>::insert(manage_action, accounts);
+
+            Self::deposit_event(Event::ActionCreated(pallet_name, pallet_extrinsic));
 
             Ok(())
         }
@@ -278,10 +278,10 @@ pub mod pallet {
                 return Err(Error::<T>::ActionNotFound.into());
             }
 
-            Self::deposit_event(Event::ActionDeleted(pallet_name, pallet_extrinsic));
-
             AccessControls::<T>::remove(execute_action);
             AccessControls::<T>::remove(manage_action);
+
+            Self::deposit_event(Event::ActionDeleted(pallet_name, pallet_extrinsic));
 
             Ok(())
         }
@@ -315,12 +315,6 @@ pub mod pallet {
                 }
             }
 
-            Self::deposit_event(Event::AccessGranted(
-                account_id.clone(),
-                action.pallet.clone(),
-                action.extrinsic.clone(),
-            ));
-
             match AccessControls::<T>::get(action.clone()) {
                 Some(mut accounts) => {
                     if accounts.contains(&account_id) {
@@ -329,11 +323,17 @@ pub mod pallet {
                     log::info!("Accounts: {:?}", accounts);
                     accounts.push(account_id.clone());
                     AccessControls::<T>::insert(action.clone(), accounts);
+
+                    Self::deposit_event(Event::AccessGranted(
+                        account_id.clone(),
+                        action.pallet.clone(),
+                        action.extrinsic.clone(),
+                    ));
+
+                    Ok(())
                 }
                 None => return Err(Error::<T>::ActionNotFound.into()),
             }
-
-            Ok(())
         }
 
         #[pallet::call_index(3)]
@@ -365,12 +365,6 @@ pub mod pallet {
                 }
             }
 
-            Self::deposit_event(Event::AccessRevoked(
-                account_id.clone(),
-                action.pallet.clone(),
-                action.extrinsic.clone(),
-            ));
-
             match AccessControls::<T>::get(action.clone()) {
                 Some(mut accounts) => {
                     if !accounts.contains(&account_id) {
@@ -378,6 +372,13 @@ pub mod pallet {
                     }
                     accounts.retain(|stored_account| stored_account != &account_id);
                     AccessControls::<T>::insert(action.clone(), accounts);
+
+                    Self::deposit_event(Event::AccessRevoked(
+                        account_id.clone(),
+                        action.pallet.clone(),
+                        action.extrinsic.clone(),
+                    ));
+
                     Ok(())
                 }
                 None => Err(Error::<T>::ActionNotFound.into()),


### PR DESCRIPTION
- fixed inline documentations
- `deposit_event` was sometimes prematurely triggering, moved them all to the end of the business logic