### PR TITLE
got rid of bounded_vec macro

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,8 +68,6 @@ pub struct AccessControl<T> {
 /// - admins
 #[frame_support::pallet]
 pub mod pallet {
-    use sp_core::bounded_vec;
-
     use super::*;
     use frame_support::{
         dispatch::DispatchResult,
@@ -126,9 +124,12 @@ pub mod pallet {
     #[cfg(feature = "std")]
     impl<T: Config> Default for GenesisConfig<T> {
         fn default() -> Self {
+            let admins: BoundedVec<T::AccountId, T::MaxAdmins> = Default::default();
+            let access_controls: BoundedVec<AccessControl<T::AccountId>, T::MaxControls> =
+                Default::default();
             Self {
-                admins: bounded_vec![],
-                access_controls: bounded_vec![],
+                admins,
+                access_controls,
             }
         }
     }
@@ -246,8 +247,10 @@ pub mod pallet {
             }
 
             let accounts: BoundedVec<T::AccountId, T::MaxAccountsPerAction> = match maybe_account {
-                Some(account) => bounded_vec![account],
-                None => bounded_vec![],
+                Some(account) => vec![account]
+                    .try_into()
+                    .expect("1 element vec is always convertible"),
+                None => Default::default(),
             };
 
             AccessControls::<T>::insert(execute_action, accounts.clone());

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -113,11 +113,11 @@ impl TestContext for WithAccessControlContext {
             access_controls: bounded_vec![
                 access_control::AccessControl {
                     action: execute_action,
-                    accounts: vec![admin_account],
+                    accounts: vec![],
                 },
                 access_control::AccessControl {
                     action: manage_action,
-                    accounts: vec![admin_account],
+                    accounts: vec![],
                 },
             ],
         }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -401,8 +401,7 @@ fn max_account_per_action_count(ctx: &mut WithAccessControlContext) {
 
             let accounts_with_access = AccessControl::access_controls(action.clone()).unwrap();
 
-            // recall, we assign an account to the action at genesis, so there is already an account here
-            if (count + 1) <= max_account_limit() {
+            if count <= max_account_limit() {
                 assert_ok!(result);
                 assert!(accounts_with_access.contains(&account_to_add));
                 true
@@ -414,13 +413,13 @@ fn max_account_per_action_count(ctx: &mut WithAccessControlContext) {
         };
 
         // Try to add accounts up to the maximum limit
-        for i in 1..max_account_limit() {
+        for i in 1..=max_account_limit() {
             // for limit, it is human counting, start from 1 instead of 0
             assert!(try_grant_access(i));
         }
 
         // Try to add one more account, expecting failure
-        assert!(!try_grant_access(max_account_limit()));
+        assert!(!try_grant_access(max_account_limit() + 1));
     });
 }
 


### PR DESCRIPTION
`bounded_vec!` macro was not recognized in the node. I triple checked the `std` imports, couldn't identify the issue. Decided to move on without the macro.

Also, now that admins have execute and manage access to all actions, no need to put them in the accounts part in the tests